### PR TITLE
feat: [sc-26306] Rename collection-templates to namegraph-collections

### DIFF
--- a/docs/readme-internal.md
+++ b/docs/readme-internal.md
@@ -1,4 +1,4 @@
-# Collections Templates Pipeline
+# NameGraph Collections Pipeline
 
 A sophisticated Apache Airflow pipeline for creating and managing topic-based name collections enriched with metadata and semantic relationships.
 
@@ -36,7 +36,7 @@ The system enables discovery of names through their conceptual connections - whe
    - Cleans up temporary files
    - Creates date file for new processing run
    - Sets up S3 backup directory
-   - Clears status of collection template DAGs
+   - Clears status of collections pipeline DAGs
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# Collections Templates Pipeline
+# NameGraph Collections Pipeline
 
 A sophisticated data pipeline that creates meaningful collections of ENS domain names by analyzing Wikipedia and Wikidata knowledge graphs. The pipeline discovers relationships between names based on their conceptual connections - whether they belong to the same category, share similar attributes, or are commonly associated together.
 
@@ -32,7 +32,7 @@ Wikipedia [Category of Pink Floyd Albums](https://en.wikipedia.org/wiki/Category
 
 ## NameGraph [[Github]](https://github.com/namehash/namegraph)
 
-Building on this collections templates pipeline, NameGraph empowers ENS registrar apps to build new name discovery user experiences. Surf more than 21 million name ideas across more than 400,000 name collections, or generate infinite related name suggestions.
+Building on this collections pipeline, NameGraph empowers ENS registrar apps to build new name discovery user experiences. Surf more than 21 million name ideas across more than 400,000 name collections, or generate infinite related name suggestions.
 
 Visit NameGraph at [namegraph.dev](https://namegraph.dev) and [shoot for the moon](https://www.namegraph.dev/collections?search=moon)!
 


### PR DESCRIPTION
Story details: https://app.shortcut.com/ps-web3/story/26306

Did not change the references in the code. Most of them are either bucket/index references or DAG's tags. First ones are too tedious to change, the second will be changed in the pipeline refactor PR.

As for the old references in the scripts, I do not see the added value in renaming them.